### PR TITLE
Fixed PostgreSQL issue with redmine 3.0.1

### DIFF
--- a/lib/redmine_release_notes/issue_patch.rb
+++ b/lib/redmine_release_notes/issue_patch.rb
@@ -75,7 +75,7 @@ module RedmineReleaseNotes
 	  conditions = "( custom_values.custom_field_id = #{cf_id}"
 	  conditions << " AND custom_values.value = '#{none_value}' )"
 
-          includes(:custom_values).where( conditions + " OR " + no_cf_defined_condition ) 
+          includes(:custom_values).joins_release_notes.where( conditions + " OR " + no_cf_defined_condition ) 
         end
 
         # issues which don't have a custom value for release notes


### PR DESCRIPTION
If the join is not there, PostgreSQL reports a missing from clause.

Tested with redmine 3.0.1.stable, rails 4.2.0, postgresql 9.4