### PR TITLE
Add REST/JSON interface to access an issue's release note

### DIFF
--- a/app/controllers/release_notes_controller.rb
+++ b/app/controllers/release_notes_controller.rb
@@ -67,10 +67,14 @@ class ReleaseNotesController < ApplicationController
     @issue = Issue.find(params[:issue_id])
     @release_note = @issue.release_note
     @format = release_notes_format_from_params
-    @content = ReleaseNotesGenerator.new(nil, @format).generate_single(@release_note)
+    if @release_note
+      @content = ReleaseNotesGenerator.new(nil, @format).generate_single(@release_note)
 
-    respond_to do |format|
-      format.api {}
+      respond_to do |format|
+        format.api {}
+      end
+    else
+      render_404
     end
   end
 

--- a/app/controllers/release_notes_controller.rb
+++ b/app/controllers/release_notes_controller.rb
@@ -63,6 +63,17 @@ class ReleaseNotesController < ApplicationController
     render_404
   end
 
+  def view
+    @issue = Issue.find(params[:issue_id])
+    @release_note = @issue.release_note
+    @format = release_notes_format_from_params
+    @content = ReleaseNotesGenerator.new(nil, @format).generate_single(@release_note)
+
+    respond_to do |format|
+      format.api {}
+    end
+  end
+
   def destroy
     release_note = ReleaseNote.find(params[:id])
     @issue = release_note.issue

--- a/app/models/release_notes_generator.rb
+++ b/app/models/release_notes_generator.rb
@@ -92,6 +92,14 @@ class ReleaseNotesGenerator
     generate_header << "\n" << generate_release_notes
   end
 
+  def generate_single(release_note)
+    str = format.start
+    str << "\n"
+    str << make_substitutions(format.each_issue, values_for_issue(release_note.issue))
+    str << "\n"
+    str << format.end
+  end
+
   private
   def generate_header
     make_substitutions(format.header, values_for_header(version))

--- a/app/views/release_notes/view.api.rsb
+++ b/app/views/release_notes/view.api.rsb
@@ -1,0 +1,7 @@
+api.release_note do
+  api.id @release_note.id
+  api.issue_id @release_note.issue_id
+  api.status @issue.release_notes_custom_value.value
+  api.text @release_note.text
+  api.formatted @content
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,12 @@ RedmineApp::Application.routes.draw do
     :to => "release_notes#generate",
     :as => :generate_release_notes
 
+  get "/issues/:issue_id/release_notes",
+    :to => 'release_notes#view',
+    :as => :release_note_view,
+    defaults: { format: 'json' }
+
+
   patch 'release_notes_formats/preview',
     :to => 'release_notes_formats#preview',
     :as => :preview_release_notes_format

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ RedmineApp::Application.routes.draw do
     :to => "release_notes#generate",
     :as => :generate_release_notes
 
-  get "/issues/:issue_id/release_notes",
+  get "/issues/:issue_id/release_note",
     :to => 'release_notes#view',
     :as => :release_note_view,
     defaults: { format: 'json' }

--- a/lib/redmine_release_notes/issues_controller_patch.rb
+++ b/lib/redmine_release_notes/issues_controller_patch.rb
@@ -16,10 +16,48 @@
 
 module RedmineReleaseNotes
   module IssuesControllerPatch
+    def self.included(base)
+      base.extend(ClassMethods)
+      base.send(:include, InstanceMethods)
+
+      base.class_eval do
+        unloadable
+        after_action :add_releasenotes_fields, :only => [:index, :show]
+      end
+    end
     def self.perform
       IssuesController.class_eval do
         helper 'release_notes'
       end
     end
+    module ClassMethods
+    end
+    module InstanceMethods
+      def add_releasenotes_fields
+        if include_in_api_response?('release_notes')
+          case params[:format]
+          when 'xml'
+            body = Nokogiri::XML(response.body)
+            body.xpath('//issue').each { |xmlissue|
+              issue = Issue.find(xmlissue.at('.//id').text)
+              next unless issue.release_notes_done?
+              xmlissue << body.create_element('release_note', issue.release_note.text)
+            }
+            response.body = body.to_xml
+          when 'json'
+            jsonp = (request.params[:callback] || request.params[:jsonp]).to_s.gsub(/[^a-zA-Z0-9_]/, '')
+            body = JSON.parse(jsonp.present? ? response.body.sub("#{jsonp}(", "").chop : response.body)
+            (body['issues'] || [body['issue']]).each{|j_issue|
+              issue = Issue.find(j_issue['id'])
+              next unless issue.release_notes_done?
+              j_issue['release_note'] = issue.release_note.text
+            }
+            response.body = jsonp.present? ? "#{jsonp}(#{body.to_json})" : body.to_json
+          end
+        end
+      end
+    end
   end
 end
+
+IssuesController.send(:include, RedmineReleaseNotes::IssuesControllerPatch) unless IssuesController.included_modules.include? RedmineReleaseNotes::IssuesControllerPatch


### PR DESCRIPTION
You're probably not interested in this pull-request, but I'm putting it here in case it's useful for anyone.